### PR TITLE
Make FastNmapScan faster and introduce a SlowNmapScan

### DIFF
--- a/actions/nmap/SlowNmapScan.py
+++ b/actions/nmap/SlowNmapScan.py
@@ -14,15 +14,15 @@ from Session import SessionManager
 
 base_path = pathlib.Path(__file__).parent.parent.parent
 
-class FastNmapScan(Action):
+class SlowNmapScan(Action):
     """
-    Implementation of shallow NMAP scan.
+    Implementation of slow shallow NMAP scan.
     This NMAP scan is performed against subnets.
     """
 
     def __init__(self):
-        super().__init__("FastNmapScan", "T1046 Network Service Discovery", "TA0007 Discovery", ["loud", "fast"])
-        self.noise = 0.8
+        super().__init__("SlowNmapScan", "T1046 Network Service Discovery", "TA0007 Discovery", ["quiet", "slow"])
+        self.noise = 0.2
         self.impact = 0
 
     def expected_outcome(self, pattern: Pattern) -> list[str]:
@@ -36,7 +36,7 @@ class FastNmapScan(Action):
 
     def get_target_query(self) -> Query:
         """
-        get_target_patterns check for fast NMAP. This NMAP finds other assets on the
+        get_target_patterns check for slow NMAP. This NMAP finds other assets on the
         network but does not identify open ports or services.
         """
         sub = Entity('Subnet', alias='subnet')
@@ -59,13 +59,13 @@ class FastNmapScan(Action):
         if ATTACK_IPS:
             res = shell(
                 "nmap",
-                ["-T4", "-F", "-sS", "-n", " ".join(ip4_attack_ips)],
+                ["-T2", "-F", "-sS", "-n", " ".join(ip4_attack_ips)],
             )
             return res
 
         res = shell(
             "nmap",
-            ["-T4", "-F", "-sS", "-n", subnet.get('network_address'), "--exclude", ",".join(ip4_non_attack_ips)],
+            ["-T2", "-F", "-sS", "-n", subnet.get('network_address'), "--exclude", ",".join(ip4_non_attack_ips)],
         )
         return res
 

--- a/actions/nmap/__init__.py
+++ b/actions/nmap/__init__.py
@@ -1,7 +1,8 @@
 from .FastNmapScan import FastNmapScan
+from .SlowNmapScan import SlowNmapScan
 from .AssetServiceScan import AssetServiceScan
 from .AssetOSScan import AssetOSScan
 from .NmapBannerScan import NmapBannerScan
 
 def get_actions() -> list:
-    return [FastNmapScan(), AssetServiceScan(), AssetOSScan(), NmapBannerScan()]
+    return [FastNmapScan(), SlowNmapScan(), AssetServiceScan(), AssetOSScan(), NmapBannerScan()]


### PR DESCRIPTION
Resolves https://github.com/Tulpa-ai/action-state-interface/issues/712

Unfortunately the sneaky (1) and paranoid (0) nmap settings make the scan on our little range take longer than the 5 min timeout on our network requests, so I've left Slow at polite (2). We'll aim to address async actions as part of the action concurrency work, which would allow us to have a really long running T0 option.