### PR TITLE
Fix ConstraintError Issues in Action Output Motifs

### DIFF
--- a/actions/hydra/HydraBruteForceAction.py
+++ b/actions/hydra/HydraBruteForceAction.py
@@ -80,6 +80,7 @@ class HydraBruteForceAction(Action):
             template_name="discovered_credentials",
             match_on=Entity('Service'),
             relationship_type='secured_with',
+            expected_attributes=["username", "password"],
             operation=StateChangeOperation.MERGE_IF_NOT_MATCH
         )
 
@@ -92,6 +93,7 @@ class HydraBruteForceAction(Action):
             match_on=Entity('Service'),
             relationship_type='is_client',
             invert_relationship=False,  # User -[is_client]-> Service (relationship is inverted in schema)
+            expected_attributes=["username"],
             operation=StateChangeOperation.MERGE_IF_NOT_MATCH
         )
 

--- a/actions/metasploit/ExploitAction.py
+++ b/actions/metasploit/ExploitAction.py
@@ -9,7 +9,7 @@ from artefacts.ArtefactManager import ArtefactManager
 from kg_api import Entity, GraphDB, Pattern, MultiPattern
 from kg_api.query import Query
 from Session import SessionManager
-from motifs import ActionInputMotif, ActionOutputMotif
+from motifs import ActionInputMotif, ActionOutputMotif, StateChangeOperation
 
 # Taken from https://docs.rapid7.com/metasploit/working-with-payloads/
 preferred_payloads = {
@@ -136,18 +136,11 @@ class ExploitAction(Action):
 
         output_motif.add_template(
             template_name="discovered_session",
-            entity=Entity('Session', alias='session', protocol='shell'),
+            entity=Entity('Session', alias='session'),
             relationship_type="executes_on",
             match_on=service,
-            expected_attributes=["id"],
-        )
-        
-        output_motif.add_template(
-            template_name="discovered_session",
-            entity=Entity('Session', alias='session', protocol='msf'),
-            relationship_type="executes_on",
-            match_on=service,
-            expected_attributes=["id"],
+            expected_attributes=["id", "protocol"],
+            operation=StateChangeOperation.MERGE_IF_NOT_MATCH,
         )
 
         return output_motif

--- a/actions/ssh/DiscoverSSHAuthMethods.py
+++ b/actions/ssh/DiscoverSSHAuthMethods.py
@@ -102,7 +102,7 @@ class DiscoverSSHAuthMethods(Action):
         output_motif.add_template(
             entity=Entity('User', alias='user'),
             template_name="updated_user",
-            operation=StateChangeOperation.UPDATE,
+            operation=StateChangeOperation.MERGE_IF_NOT_MATCH,
             expected_attributes=["ssh_authentication"],
         )
         output_motif.add_template(
@@ -191,9 +191,16 @@ class DiscoverSSHAuthMethods(Action):
         user_from_pattern = pattern.get('user')
         ssh_service_from_pattern = pattern.get('ssh_service')
 
+        # IMPORTANT: when using MERGE operations, the Cypher builder can end up with
+        # the `user` variable already bound by the match pattern. If we then emit a
+        # `MERGE (user)` again, Neo4j raises "Variable `user` already declared".
+        # To avoid this, we create a match-on User entity with a different alias.
+        user_uuid = user_from_pattern.get("uuid")
+        user_match = Entity("User", alias="ssh_user", uuid=user_uuid)
+
         changes.append(self.output_motif.instantiate(
             template_name="updated_user",
-            match_on_override=user_from_pattern,
+            match_on_override=user_match,
             ssh_authentication=discovered_data["ssh_authentication"],
         ))
         


### PR DESCRIPTION
Fix ConstraintError Issues in Action Output Motifs

This PR fixes neo4j.exceptions.ConstraintError issues that occurred when actions attempted to create nodes (Session, User, Credentials) that already existed in the Neo4j graph database. The fixes ensure that actions use MERGE_IF_NOT_MATCH operations with appropriate expected_attributes to properly match and merge with existing nodes instead of creating duplicates.

Implementation Details
DiscoverSSHAuthMethods Action
- Changed the updated_user template operation from UPDATE to MERGE_IF_NOT_MATCH to prevent constraint errors when updating User nodes that already exist
- Fixed a CypherSyntaxError by using a different alias (ssh_user) when instantiating the User entity to avoid variable redeclaration in generated Cypher queries
- Added expected_attributes=["ssh_authentication"] to ensure proper matching of existing User nodes

ExploitAction (Metasploit Exploits)
- Ensured the discovered_session template uses operation=StateChangeOperation.MERGE_IF_NOT_MATCH with expected_attributes=["id", "protocol"]
- This prevents constraint errors when multiple exploit attempts create Session nodes with the same session ID and protocol

HydraBruteForceAction
- Added expected_attributes=["username", "password"] to the discovered_credentials template to ensure Credentials nodes are properly matched and merged when the same username/password combination is discovered multiple times
- Added expected_attributes=["username"] to the discovered_user template to ensure User nodes are properly matched and merged when the same username is discovered multiple times
- Both templates use operation=StateChangeOperation.MERGE_IF_NOT_MATCH to prevent duplicate node creation

Testing Steps

Run the following actions and check logs to ensure we don't see any neo4j.exceptions.ConstraintError errors:
- DiscoverSSHAuthMethods - Run on assets with SSH services and verify no constraint errors for User nodes
- MsfUnixIrcUnrealIrcd3281BackdoorExploit (or other Metasploit exploits) - Run exploit actions and verify no constraint errors for Session nodes
- HydraBruteForceAction - Run brute force attempts and verify no constraint errors for Credentials or User nodes

Expected log error format to avoid:

`neo4j.exceptions.ConstraintError: {code: Neo.ClientError.Schema.ConstraintValidationFailed} {message: Node(673) already exists with label `Session` and property `uuid` = '41a711c3-a5b0-4b4b-947c-a30cde058db9'}`